### PR TITLE
Add missing "use" of wcf\data\user\UserProfile

### DIFF
--- a/files/lib/data/user/group/premium/UserGroupPremiumAction.class.php
+++ b/files/lib/data/user/group/premium/UserGroupPremiumAction.class.php
@@ -9,9 +9,10 @@ use wcf\system\exception\IllegalLinkException;
 use wcf\system\exception\PermissionDeniedException;
 use wcf\system\user\storage\UserStorageHandler;
 use wcf\system\WCF;
-use wcf\data\user\UserEditor; 
+use wcf\data\user\User;
+use wcf\data\user\UserEditor;
+use wcf\data\user\UserProfile;
 use wcf\data\user\UserProfileAction;
-use wcf\data\user\User; 
 
 /**
  * Provides functions to handle premium-groups.


### PR DESCRIPTION
Currently users can't buy groups but the sum is being deducted from their account.

@see https://tims.bastelstu.be/forum/index.php/Thread/200-Update-1-0-5-erzeugt-Fatal-Error
